### PR TITLE
feat: switch to ironbank images

### DIFF
--- a/.github/workflows/package.build-and-publish.yaml
+++ b/.github/workflows/package.build-and-publish.yaml
@@ -32,6 +32,12 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Login to Registry1
+      uses: docker/login-action@v3
+      with:
+        registry: registry1.dso.mil
+        username: ${{ secrets.REGISTRY1_USERNAME }}
+        password: ${{ secrets.REGISTRY1_PASSWORD }}
     - name: Install Zarf
       uses: defenseunicorns/setup-zarf@main
       with:

--- a/kustomizations/kustomization.yaml
+++ b/kustomizations/kustomization.yaml
@@ -1,0 +1,42 @@
+resources:
+- https://raw.githubusercontent.com/metallb/metallb/v0.13.11/config/manifests/metallb-native.yaml
+
+images:
+- name: quay.io/metallb/controller
+  newName: registry1.dso.mil/ironbank/opensource/metallb/controller
+  newTag: v0.13.11
+- name: quay.io/metallb/speaker
+  newName: registry1.dso.mil/ironbank/opensource/metallb/speaker
+  newTag: v0.13.11
+
+patches:
+  - target:
+      kind: Deployment
+      name: controller
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: controller
+      spec:
+        template:
+          spec:
+            securityContext:
+              fsGroup: 65532
+              runAsNonRoot: true
+              runAsUser: 65532
+              runAsGroup: 65532
+  - target:
+      kind: DaemonSet
+      name: speaker
+    patch: |-
+      apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: speaker
+      spec:
+        template:
+          spec:
+            securityContext:
+              fsGroup: 65532
+              runAsUser: 0

--- a/zarf-config.yaml
+++ b/zarf-config.yaml
@@ -1,3 +1,7 @@
 package:
   create:
     max_package_size: "1000000000"
+  deploy:
+    set:
+      ip_address_admin_ingressgateway: "192.168.123.100"
+      ip_address_tenant_ingressgateway: "192.168.123.101"

--- a/zarf-config.yaml
+++ b/zarf-config.yaml
@@ -1,7 +1,3 @@
 package:
   create:
     max_package_size: "1000000000"
-  deploy:
-    set:
-      ip_address_admin_ingressgateway: "192.168.123.100"
-      ip_address_tenant_ingressgateway: "192.168.123.101"

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -41,15 +41,13 @@ components:
 
   - name: metallb
     required: true
-    charts:
+    manifests:
       - name: metallb
-        version: 0.13.10
-        namespace: metallb-system
-        url: https://metallb.github.io/metallb
+        kustomizations:
+          - kustomizations/
     images:
-      - quay.io/frrouting/frr:8.4.2
-      - quay.io/metallb/controller:v0.13.10
-      - quay.io/metallb/speaker:v0.13.10
+      - registry1.dso.mil/ironbank/opensource/metallb/controller:v0.13.11
+      - registry1.dso.mil/ironbank/opensource/metallb/speaker:v0.13.11
 
   - name: addresspools
     required: true


### PR DESCRIPTION
This switches to using the new Ironbank images for MetalLB. Due to limitations with securityContext not being exposed in the MetalLB helm chart this also switches to installing via a kustomization layered over the upstream manifest. This is listed as one of recommended/supported install methods upstream so I don't think it is a problem - https://metallb.universe.tf/installation/