### PR TITLE
chore: add uds-foundry to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
-* @uds-packages/maintainers
+* @uds-packages/maintainers @uds-packages/uds-foundry
 
 # NOTE: No E to catch LICENSE and LICENSING
-/CODEOWNERS @jeff-mccoy @daveworth 
+/CODEOWNERS @jeff-mccoy @daveworth
 /LICENS* @jeff-mccoy @austenbryan

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
+# This repository is owned by the UDS Foundry Team
 * @uds-packages/maintainers @uds-packages/uds-foundry
 
 # NOTE: No E to catch LICENSE and LICENSING


### PR DESCRIPTION
## Description

Add @uds-packages/uds-foundry to CODEOWNERS for [foundry-owned packages](https://www.notion.so/defense-unicorns/Projects-UDS-Foundry-Supports-26ae512f24fc80e18cdbe7c7b68cc979) for consistency.

## Related Issue

Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
