### PR TITLE
fix: align l2 advertisement with addresspool

### DIFF
--- a/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
@@ -5,11 +5,11 @@
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
-  name: keycloak-ingressgateway
+  name: passthrough-ingressgateway
   namespace: metallb-system
 spec:
   ipAddressPools:
-    - keycloak-ingressgateway
+    - passthrough-ingressgateway
   {{- if .Values.interface }}
   interfaces:
     - {{ .Values.interface }}

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=quay.io/metallb/controller extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 0.15.3-uds.1
+    version: 0.15.3-uds.2
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/metallb/controller extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 0.15.3-uds.3
+    version: 0.15.3-uds.4
   - name: unicorn
     # renovate-uds: datasource=docker depName=quay.io/rfcurated/metallb/controller extractVersion=^(?<version>\d+\.\d+\.\d+)(?:-.*)?$
-    version: 0.15.2-uds.8
+    version: 0.15.2-uds.9


### PR DESCRIPTION
In working with @eddiezane we identified that the l2 advertisment was not lined up with the corresponding address pool.

In theory this could be a breaking change but it looks like a bug and would've required some hackiness to work around.