### PR TITLE
ci: update ci test coverage and approach

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,9 +2,10 @@ yaml-files:
   - '**/*.y*ml'
   - '.yamllint'
 
-# Ignore files from upstream
+# Ignore Helm chart templates (Go template syntax is not valid YAML)
 ignore:
   - '**/charts/**/templates**'
+  - '**/chart/templates**'
 
 rules:
   anchors: enable

--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -17,7 +17,7 @@ packages:
 
   - name: core-crds
     repository: ghcr.io/defenseunicorns/packages/uds/core-crds
-    ref: 1.3.0-upstream
+    ref: 1.8.0-upstream
 
   - name: metallb
     path: ../
@@ -25,6 +25,6 @@ packages:
 
   - name: core-base
     repository: ghcr.io/defenseunicorns/packages/uds/core-base
-    ref: 1.3.0-upstream
+    ref: 1.8.0-upstream
     optionalComponents:
       - istio-passthrough-gateway

--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 kind: UDSBundle
@@ -12,6 +12,16 @@ packages:
     repository: ghcr.io/zarf-dev/packages/init
     ref: v0.75.1
 
+  - name: core-crds
+    repository: ghcr.io/defenseunicorns/packages/uds/core-crds
+    ref: 1.3.0-upstream
+
   - name: metallb
     path: ../
     ref: dev
+
+  - name: core-base
+    repository: ghcr.io/defenseunicorns/packages/uds/core-base
+    ref: 1.3.0-upstream
+    optionalComponents:
+      - istio-passthrough-gateway

--- a/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 {{- if .Values.passthroughIngress.ipAddressPool }}

--- a/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
+++ b/charts/addresspools/templates/l2advertisement-passthrough-ingressgateway.yaml
@@ -5,11 +5,11 @@
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
-  name: keycloak-ingressgateway
+  name: passthrough-ingressgateway
   namespace: metallb-system
 spec:
   ipAddressPools:
-    - keycloak-ingressgateway
+    - passthrough-ingressgateway
   {{- if .Values.interface }}
   interfaces:
     - {{ .Values.interface }}

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -4,10 +4,10 @@
 flavors:
   - name: upstream
     # renovate-uds: datasource=docker depName=quay.io/metallb/controller extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 0.15.3-uds.1
+    version: 0.15.3-uds.2
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/metallb/controller extractVersion=^v(?<version>\d+\.\d+\.\d+)$
-    version: 0.15.3-uds.3
+    version: 0.15.3-uds.4
   - name: unicorn
     # renovate-uds: datasource=docker depName=quay.io/rfcurated/metallb/controller extractVersion=^(?<version>\d+\.\d+\.\d+)(?:-.*)?$
-    version: 0.15.2-uds.8
+    version: 0.15.2-uds.9

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Defense Unicorns
+# Copyright 2024-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:
@@ -39,9 +39,14 @@ tasks:
           echo "${BASE_IP}.240-${BASE_IP}.250"
         setVariables:
           - name: METALLB_RANGE
+      - cmd: |
+          BASE_IP=$(./uds zarf tools kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' | cut -d'.' -f1-3)
+          echo "${BASE_IP}.239"
+        setVariables:
+          - name: PASSTHROUGH_IP
       - task: deploy:test-bundle
         with:
-          options: "--set IP_ADDRESS_POOL=${METALLB_RANGE}"
+          options: "--set IP_ADDRESS_POOL=${METALLB_RANGE} --set IP_ADDRESS_PASSTHROUGH_INGRESSGATEWAY=${PASSTHROUGH_IP}"
       - task: test:all
 
   - name: dev
@@ -54,9 +59,14 @@ tasks:
           echo "${BASE_IP}.240-${BASE_IP}.250"
         setVariables:
           - name: METALLB_RANGE
+      - cmd: |
+          BASE_IP=$(./zarf tools kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' | cut -d'.' -f1-3)
+          echo "${BASE_IP}.239"
+        setVariables:
+          - name: PASSTHROUGH_IP
       - task: deploy:test-bundle
         with:
-          options: "--set IP_ADDRESS_POOL=${METALLB_RANGE}"
+          options: "--set IP_ADDRESS_POOL=${METALLB_RANGE} --set IP_ADDRESS_PASSTHROUGH_INGRESSGATEWAY=${PASSTHROUGH_IP}"
 
 # CI will execute the following (via uds-common/.github/workflows/callable-[test|publish].yaml) so they need to be here with these names
 

--- a/tasks/cluster.yaml
+++ b/tasks/cluster.yaml
@@ -15,5 +15,5 @@ tasks:
             --k3s-arg "--disable=traefik@server:*" \
             --k3s-arg "--disable=metrics-server@server:*" \
             --k3s-arg "--disable=servicelb@server:*" \
-            --image rancher/k3s:v1.32.5-k3s1 \
+            --image rancher/k3s:v1.35.4-k3s1 \
             uds

--- a/tasks/cluster.yaml
+++ b/tasks/cluster.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 tasks:
@@ -7,6 +7,8 @@ tasks:
     actions:
       - description: Create a K3d cluster to install metallb on
         cmd: |
+          # renovate: datasource=docker depName=rancher/k3s versioning=docker
+          K3S_IMAGE=rancher/k3s:v1.35.4-k3s1
           k3d cluster delete uds
           k3d cluster create \
             -p "80:80@server:*" \
@@ -15,5 +17,5 @@ tasks:
             --k3s-arg "--disable=traefik@server:*" \
             --k3s-arg "--disable=metrics-server@server:*" \
             --k3s-arg "--disable=servicelb@server:*" \
-            --image rancher/k3s:v1.35.4-k3s1 \
+            --image "$K3S_IMAGE" \
             uds

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Defense Unicorns
+# Copyright 2025-2026 Defense Unicorns
 # SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
 
 includes:
@@ -7,30 +7,10 @@ includes:
 tasks:
   - name: all
     actions:
-      - task: deploy-uds-core
-      - task: deploy-metallb-exemption
       - task: restart-metallb-speaker
       - task: deploy-uds-core-identity-authorization
+      - task: deploy-passthrough-test
       - task: test-metallb-lb
-
-  - name: deploy-uds-core
-    description: Deploy UDS Core base
-    actions:
-      - cmd: |
-          # renovate: datasource=docker depName=ghcr.io/defenseunicorns/packages/uds/core-base versioning=docker
-          ./uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/uds/core-base:1.3.0-upstream --confirm
-
-  - name: deploy-metallb-exemption
-    description: Deploy MetalLB with the optional exemption component
-    actions:
-      - cmd: |
-          BASE_IP=$(./uds zarf tools kubectl get nodes -o=jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' | cut -d'.' -f1-3)
-          echo "${BASE_IP}.240-${BASE_IP}.250"
-        setVariables:
-          - name: METALLB_RANGE
-      - task: deploy:package
-        with:
-          options: "--set IP_ADDRESS_POOL=${METALLB_RANGE}"
 
   - name: restart-metallb-speaker
     description: Restart the MetalLB speaker to ensure the exemption is applied
@@ -51,15 +31,43 @@ tasks:
           # renovate: datasource=docker depName=ghcr.io/defenseunicorns/packages/uds/core-identity-authorization versioning=docker
           ./uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/uds/core-identity-authorization:1.3.0-upstream --confirm
 
-  - name: test-metallb-lb
-    description: Test that MetalLB is functioning by checking the Keycloak endpoint
+  - name: deploy-passthrough-test
+    description: Build and deploy the local passthrough-test package (backend behind the passthrough gateway)
     actions:
       - cmd: |
+          ./uds zarf package create tests/passthrough --skip-sbom --confirm -o tests/passthrough
+          ./uds zarf package deploy tests/passthrough/zarf-package-passthrough-test-*.tar.zst --confirm
+
+  - name: test-metallb-lb
+    description: Validate each MetalLB pool is allocating + L2-advertising
+    actions:
+      - description: tenant pool — Keycloak public endpoint reachable via tenant gateway IP
+        cmd: |
           TENANT_IP=$(kubectl get svc tenant-ingressgateway -n istio-tenant-gateway -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
-          if docker run  --network=k3d-uds --add-host "sso.uds.dev:${TENANT_IP}" curlimages/curl:latest curl -L https://sso.uds.dev | grep -q "My Account"; then
-            echo "Successfully hit Keycloak through MetalLB"
+          if docker run --network=k3d-uds --add-host "sso.uds.dev:${TENANT_IP}" curlimages/curl:latest curl -skL https://sso.uds.dev | grep -q "My Account"; then
+            echo "Successfully hit Keycloak through tenant gateway"
           else
-            echo "Failed to make a request to Keycloak through MetalLB"
+            echo "Failed to hit Keycloak through tenant gateway"
+            exit 1
+          fi
+      - description: admin pool — Keycloak admin endpoint reachable via admin gateway IP
+        cmd: |
+          ADMIN_IP=$(kubectl get svc admin-ingressgateway -n istio-admin-gateway -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+          if docker run --network=k3d-uds --add-host "keycloak.admin.uds.dev:${ADMIN_IP}" curlimages/curl:latest curl -skL https://keycloak.admin.uds.dev | grep -q "Welcome to Keycloak"; then
+            echo "Successfully hit Keycloak through admin gateway"
+          else
+            echo "Failed to hit Keycloak through admin gateway"
+            exit 1
+          fi
+      - description: passthrough pool — nginx endpoint reachable via passthrough gateway IP
+        cmd: |
+          PASSTHROUGH_IP=$(kubectl get svc passthrough-ingressgateway -n istio-passthrough-gateway -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+          if docker run --network=k3d-uds --add-host "passthrough.uds.dev:${PASSTHROUGH_IP}" curlimages/curl:latest curl -sk --max-time 10 https://passthrough.uds.dev/ | grep -q "passthrough ok"; then
+            echo "Successfully hit passthrough-test through passthrough gateway"
+          else
+            echo "Failed to hit passthrough-test through passthrough gateway"
             exit 1
           fi

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -36,7 +36,7 @@ tasks:
     actions:
       - cmd: |
           ./uds zarf package create tests/passthrough --skip-sbom --confirm -o tests/passthrough
-          ./uds zarf package deploy tests/passthrough/zarf-package-passthrough-test-*.tar.zst --confirm
+          ./uds zarf package deploy tests/passthrough/zarf-package-passthrough-test-${UDS_ARCH}-dev.tar.zst --confirm
 
   - name: test-metallb-lb
     description: Validate each MetalLB pool is allocating + L2-advertising

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -36,7 +36,7 @@ tasks:
     actions:
       - cmd: |
           ./uds zarf package create tests/passthrough --skip-sbom --confirm -o tests/passthrough
-          ./uds zarf package deploy tests/passthrough/zarf-package-passthrough-test-${UDS_ARCH}-dev.tar.zst --confirm
+          ./uds zarf package deploy "tests/passthrough/zarf-package-passthrough-test-${UDS_ARCH}-dev.tar.zst" --confirm
 
   - name: test-metallb-lb
     description: Validate each MetalLB pool is allocating + L2-advertising

--- a/tests/passthrough/chart/Chart.yaml
+++ b/tests/passthrough/chart/Chart.yaml
@@ -6,4 +6,4 @@ name: passthrough-test
 description: Backend nginx exposed via the istio passthrough gateway, used to validate the MetalLB passthrough address pool end-to-end
 type: application
 version: 0.1.0
-appVersion: "1.27.3"
+appVersion: "1.30.0"

--- a/tests/passthrough/chart/Chart.yaml
+++ b/tests/passthrough/chart/Chart.yaml
@@ -1,0 +1,9 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: v2
+name: passthrough-test
+description: Backend nginx exposed via the istio passthrough gateway, used to validate the MetalLB passthrough address pool end-to-end
+type: application
+version: 0.1.0
+appVersion: "1.27.3"

--- a/tests/passthrough/chart/templates/cert-secret.yaml
+++ b/tests/passthrough/chart/templates/cert-secret.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+{{- $fqdn := printf "%s.uds.dev" .Values.host }}
+{{- $cert := genSelfSignedCert $fqdn nil (list $fqdn) 3650 }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: passthrough-test-tls
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}

--- a/tests/passthrough/chart/templates/configmap.yaml
+++ b/tests/passthrough/chart/templates/configmap.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: passthrough-test-config
+data:
+  default.conf: |
+    server {
+      listen 8443 ssl;
+      ssl_certificate     /etc/nginx/tls/tls.crt;
+      ssl_certificate_key /etc/nginx/tls/tls.key;
+
+      location / {
+        default_type text/plain;
+        return 200 "passthrough ok\n";
+      }
+    }

--- a/tests/passthrough/chart/templates/deployment.yaml
+++ b/tests/passthrough/chart/templates/deployment.yaml
@@ -1,0 +1,43 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: passthrough-test
+  labels:
+    app: passthrough-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: passthrough-test
+  template:
+    metadata:
+      labels:
+        app: passthrough-test
+    spec:
+      containers:
+        - name: nginx
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - name: tls
+              containerPort: 8443
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d
+            - name: tls
+              mountPath: /etc/nginx/tls
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 2
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: passthrough-test-config
+        - name: tls
+          secret:
+            secretName: passthrough-test-tls

--- a/tests/passthrough/chart/templates/package.yaml
+++ b/tests/passthrough/chart/templates/package.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: uds.dev/v1alpha1
+kind: Package
+metadata:
+  name: passthrough-test
+spec:
+  network:
+    expose:
+      - service: passthrough-test
+        selector:
+          app: passthrough-test
+        host: {{ .Values.host }}
+        gateway: passthrough
+        port: 443
+        targetPort: 8443

--- a/tests/passthrough/chart/templates/service.yaml
+++ b/tests/passthrough/chart/templates/service.yaml
@@ -1,0 +1,16 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: passthrough-test
+  labels:
+    app: passthrough-test
+spec:
+  selector:
+    app: passthrough-test
+  ports:
+    - name: tls
+      port: 443
+      targetPort: 8443

--- a/tests/passthrough/chart/values.yaml
+++ b/tests/passthrough/chart/values.yaml
@@ -3,6 +3,6 @@
 
 image:
   repository: nginxinc/nginx-unprivileged
-  tag: 1.27.3-alpine
+  tag: 1.30.0-alpine
 
 host: passthrough

--- a/tests/passthrough/chart/values.yaml
+++ b/tests/passthrough/chart/values.yaml
@@ -1,0 +1,8 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+image:
+  repository: nginxinc/nginx-unprivileged
+  tag: 1.27.3-alpine
+
+host: passthrough

--- a/tests/passthrough/zarf.yaml
+++ b/tests/passthrough/zarf.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+kind: ZarfPackageConfig
+metadata:
+  name: passthrough-test
+  description: Test backend exposed via the istio passthrough gateway, used to validate the MetalLB passthrough address pool end-to-end
+  version: dev
+
+components:
+  - name: passthrough-test
+    required: true
+    charts:
+      - name: passthrough-test
+        namespace: passthrough-test
+        localPath: ./chart
+        version: 0.1.0
+    images:
+      - nginxinc/nginx-unprivileged:1.27.3-alpine

--- a/tests/passthrough/zarf.yaml
+++ b/tests/passthrough/zarf.yaml
@@ -16,4 +16,4 @@ components:
         localPath: ./chart
         version: 0.1.0
     images:
-      - nginxinc/nginx-unprivileged:1.27.3-alpine
+      - nginxinc/nginx-unprivileged:1.30.0-alpine


### PR DESCRIPTION
This PR contains CI only updates:
- add coverage of the admin gateway in CI using the keycloak admin endpoint
- refactor test bundle to leverage new `core-crds` layer to not have to redeploy after core
- add an nginx test package for the passthrough gateway
- updated k3s to latest n-1