### PR TITLE
chore: swap rf images for cgr

### DIFF
--- a/releaser.yaml
+++ b/releaser.yaml
@@ -9,5 +9,5 @@ flavors:
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/opensource/metallb/controller extractVersion=^v(?<version>\d+\.\d+\.\d+)$
     version: 0.15.3-uds.4
   - name: unicorn
-    # renovate-uds: datasource=docker depName=quay.io/rfcurated/metallb/controller extractVersion=^(?<version>\d+\.\d+\.\d+)(?:-.*)?$
-    version: 0.15.2-uds.9
+    # renovate-uds: datasource=docker depName=cgr.dev/defenseunicorns.com/metallb-controller extractVersion=^(?<version>\d+\.\d+\.\d+)$
+    version: 0.15.3-uds.0

--- a/values/unicorn-values.yaml
+++ b/values/unicorn-values.yaml
@@ -3,10 +3,10 @@
 
 controller:
   image:
-    repository: quay.io/rfcurated/metallb/controller
-    tag: 0.15.2-jammy-scratch-fips-rfcurated
+    repository: cgr.dev/defenseunicorns.com/metallb-controller
+    tag: 0.15.3
 
 speaker:
   image:
-    repository: quay.io/rfcurated/metallb/speaker
-    tag: 0.15.2-jammy-scratch-fips-rfcurated
+    repository: cgr.dev/defenseunicorns.com/metallb-speaker
+    tag: 0.15.3

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -88,5 +88,5 @@ components:
         valuesFiles:
           - ./values/unicorn-values.yaml
     images:
-      - quay.io/rfcurated/metallb/controller:0.15.2-jammy-scratch-fips-rfcurated
-      - quay.io/rfcurated/metallb/speaker:0.15.2-jammy-scratch-fips-rfcurated
+      - cgr.dev/defenseunicorns.com/metallb-controller:0.15.3
+      - cgr.dev/defenseunicorns.com/metallb-speaker:0.15.3


### PR DESCRIPTION
Rapidfort -> Chainguard

Related to [FDRY-101](https://linear.app/defense-unicorns/issue/FDRY-101/update-metallb-package-for-chainguard-images)