### PR TITLE
fix: add keylessVerification for zarf init, disable frrk8s

### DIFF
--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -11,6 +11,9 @@ packages:
   - name: init
     repository: ghcr.io/zarf-dev/packages/init
     ref: v0.80.0
+    keylessVerification:
+      certificateIdentityRegexp: https://github.com/zarf-dev/zarf/.github/workflows/release.yml@refs/tags/v\d+\.\d+.\d+
+      certificateOIDCIssuer: https://token.actions.githubusercontent.com
 
   - name: metallb
     path: ../

--- a/values/common-values.yaml
+++ b/values/common-values.yaml
@@ -14,3 +14,6 @@ speaker:
     runAsUser: 0
   frr:
     enabled: false
+
+frrk8s:
+  enabled: false


### PR DESCRIPTION
Adds a couple of changes needed for #119 to pass CI
- `keylessVerification` for zarf init package in the demo bundle
- Set `frrk8s.enabled` to `false` since the upstream chart is now enabling it by default