### PR TITLE
fix: zarf-init keyless signing regex

### DIFF
--- a/bundle/uds-bundle.yaml
+++ b/bundle/uds-bundle.yaml
@@ -12,7 +12,7 @@ packages:
     repository: ghcr.io/zarf-dev/packages/init
     ref: v0.80.0
     keylessVerification:
-      certificateIdentityRegexp: https://github.com/zarf-dev/zarf/.github/workflows/release.yml@refs/tags/v\d+\.\d+.\d+
+      certificateIdentityRegexp: "https://github\\.com/zarf-dev/zarf/\\.github/workflows/release\\.yml@refs/tags/v\\d+\\.\\d+\\.\\d+"
       certificateOIDCIssuer: https://token.actions.githubusercontent.com
 
   - name: metallb


### PR DESCRIPTION
Update `certificateIdentityRegexp` with proper escaping to (hopefully) fix: https://github.com/uds-packages/metallb/actions/runs/28515433583/job/84525888693