### PR TITLE
feat: expose package configuration via Zarf Values

### DIFF
--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -18,11 +18,28 @@ components:
         version: 0.16.1
         valuesFiles:
           - "../values/common-values.yaml"
+        values:
+          - sourcePath: .metallb
+            targetPath: .
+            excludePaths:
+              - .metallb.imagePullSecrets
+              - .metallb.controller.image
+              - .metallb.controller.securityContext
+              - .metallb.speaker.image
+              - .metallb.speaker.securityContext
+              - .metallb.speaker.frr.image
+              - .metallb.crds
+              - .metallb.frr-k8s.frrk8s.image
+              - .metallb.frr-k8s.frrk8s.frr.image
+              - .metallb.frr-k8s.crds
       - name: addresspools
         serverSideApply: "false"
         version: "0.1.2"
         namespace: metallb-system
         localPath: ../charts/addresspools
+        values:
+          - sourcePath: .addresspools
+            targetPath: .
         variables:
           - name: INTERFACE
             path: interface

--- a/zarf-values.schema.json
+++ b/zarf-values.schema.json
@@ -1,0 +1,753 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "addresspools": {
+      "properties": {
+        "adminIngress": {
+          "properties": {
+            "ipAddressPool": {
+              "type": "string"
+            },
+            "matchLabels": {
+              "properties": {
+                "app": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "default": {
+          "properties": {
+            "ipAddressPoolCIDR": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "interface": {
+          "type": "string"
+        },
+        "passthroughIngress": {
+          "properties": {
+            "ipAddressPool": {
+              "type": "string"
+            },
+            "matchLabels": {
+              "properties": {
+                "app": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "tenantIngress": {
+          "properties": {
+            "ipAddressPool": {
+              "type": "string"
+            },
+            "matchLabels": {
+              "properties": {
+                "app": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "exemption": {
+      "properties": {
+        "exemptionEnabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "metallb": {
+      "properties": {
+        "controller": {
+          "properties": {
+            "affinity": {
+              "properties": {},
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "extraContainers": {
+              "type": "array"
+            },
+            "labels": {
+              "properties": {},
+              "type": "object"
+            },
+            "livenessProbe": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failureThreshold": {
+                  "type": "number"
+                },
+                "initialDelaySeconds": {
+                  "type": "number"
+                },
+                "periodSeconds": {
+                  "type": "number"
+                },
+                "port": {
+                  "type": "number"
+                },
+                "successThreshold": {
+                  "type": "number"
+                },
+                "timeoutSeconds": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "logLevel": {
+              "type": "string"
+            },
+            "nodeSelector": {
+              "properties": {},
+              "type": "object"
+            },
+            "podAnnotations": {
+              "properties": {},
+              "type": "object"
+            },
+            "priorityClassName": {
+              "type": "string"
+            },
+            "readinessProbe": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failureThreshold": {
+                  "type": "number"
+                },
+                "initialDelaySeconds": {
+                  "type": "number"
+                },
+                "periodSeconds": {
+                  "type": "number"
+                },
+                "port": {
+                  "type": "number"
+                },
+                "successThreshold": {
+                  "type": "number"
+                },
+                "timeoutSeconds": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "resources": {
+              "properties": {},
+              "type": "object"
+            },
+            "runtimeClassName": {
+              "type": "string"
+            },
+            "serviceAccount": {
+              "properties": {
+                "annotations": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "create": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "strategy": {
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array"
+            },
+            "webhookMode": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "frr-k8s": {
+          "properties": {
+            "prometheus": {
+              "properties": {
+                "serviceMonitor": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "frrk8s": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "external": {
+              "type": "boolean"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "fullnameOverride": {
+          "type": "string"
+        },
+        "loadBalancerClass": {
+          "type": "string"
+        },
+        "nameOverride": {
+          "type": "string"
+        },
+        "networkpolicies": {
+          "properties": {
+            "apiPort": {
+              "type": "number"
+            },
+            "defaultDeny": {
+              "type": "boolean"
+            },
+            "enabled": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "prometheus": {
+          "properties": {
+            "metricsPort": {
+              "type": "number"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "podMonitor": {
+              "properties": {
+                "additionalLabels": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "annotations": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "interval": {
+                  "type": "string"
+                },
+                "jobLabel": {
+                  "type": "string"
+                },
+                "metricRelabelings": {
+                  "type": "array"
+                },
+                "relabelings": {
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "prometheusRule": {
+              "properties": {
+                "additionalLabels": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "addressPoolExhausted": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "excludePools": {
+                      "type": "string"
+                    },
+                    "labels": {
+                      "properties": {
+                        "severity": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "addressPoolUsage": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "excludePools": {
+                      "type": "string"
+                    },
+                    "thresholds": {
+                      "items": {
+                        "properties": {
+                          "labels": {
+                            "properties": {
+                              "severity": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "percent": {
+                            "type": "number"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "annotations": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "bgpSessionDown": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "labels": {
+                      "properties": {
+                        "severity": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "configNotLoaded": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "labels": {
+                      "properties": {
+                        "severity": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "extraAlerts": {
+                  "type": "array"
+                },
+                "staleConfig": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "labels": {
+                      "properties": {
+                        "severity": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "rbacPrometheus": {
+              "type": "boolean"
+            },
+            "scrapeAnnotations": {
+              "type": "boolean"
+            },
+            "serviceAccount": {
+              "type": "string"
+            },
+            "serviceMonitor": {
+              "properties": {
+                "controller": {
+                  "properties": {
+                    "additionalLabels": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "annotations": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "tlsConfig": {
+                      "properties": {
+                        "insecureSkipVerify": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "interval": {
+                  "type": "string"
+                },
+                "jobLabel": {
+                  "type": "string"
+                },
+                "metricRelabelings": {
+                  "type": "array"
+                },
+                "relabelings": {
+                  "type": "array"
+                },
+                "speaker": {
+                  "properties": {
+                    "additionalLabels": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "annotations": {
+                      "properties": {},
+                      "type": "object"
+                    },
+                    "tlsConfig": {
+                      "properties": {
+                        "insecureSkipVerify": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "rbac": {
+          "properties": {
+            "create": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "speaker": {
+          "properties": {
+            "affinity": {
+              "properties": {},
+              "type": "object"
+            },
+            "bgpDebounceTimeout": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "excludeInterfaces": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "extraContainers": {
+              "type": "array"
+            },
+            "frr": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "metricsPort": {
+                  "type": "number"
+                },
+                "resources": {
+                  "properties": {},
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "frrMetrics": {
+              "properties": {
+                "resources": {
+                  "properties": {},
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "ignoreExcludeLB": {
+              "type": "boolean"
+            },
+            "initContainers": {
+              "properties": {
+                "cpFrrFiles": {
+                  "properties": {
+                    "resources": {
+                      "properties": {},
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "cpMetrics": {
+                  "properties": {
+                    "resources": {
+                      "properties": {},
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "cpReloader": {
+                  "properties": {
+                    "resources": {
+                      "properties": {},
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "labels": {
+              "properties": {},
+              "type": "object"
+            },
+            "livenessProbe": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failureThreshold": {
+                  "type": "number"
+                },
+                "initialDelaySeconds": {
+                  "type": "number"
+                },
+                "periodSeconds": {
+                  "type": "number"
+                },
+                "port": {
+                  "type": "number"
+                },
+                "successThreshold": {
+                  "type": "number"
+                },
+                "timeoutSeconds": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "logLevel": {
+              "type": "string"
+            },
+            "memberlist": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "mlBindAddrOverride": {
+                  "type": "string"
+                },
+                "mlBindPort": {
+                  "type": "number"
+                },
+                "mlSecretKeyPath": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "nodeSelector": {
+              "properties": {},
+              "type": "object"
+            },
+            "podAnnotations": {
+              "properties": {},
+              "type": "object"
+            },
+            "priorityClassName": {
+              "type": "string"
+            },
+            "readinessProbe": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failureThreshold": {
+                  "type": "number"
+                },
+                "initialDelaySeconds": {
+                  "type": "number"
+                },
+                "periodSeconds": {
+                  "type": "number"
+                },
+                "port": {
+                  "type": "number"
+                },
+                "successThreshold": {
+                  "type": "number"
+                },
+                "timeoutSeconds": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "reloader": {
+              "properties": {
+                "resources": {
+                  "properties": {},
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "resources": {
+              "properties": {},
+              "type": "object"
+            },
+            "runtimeClassName": {
+              "type": "string"
+            },
+            "serviceAccount": {
+              "properties": {
+                "annotations": {
+                  "properties": {},
+                  "type": "object"
+                },
+                "create": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "startupProbe": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "failureThreshold": {
+                  "type": "number"
+                },
+                "periodSeconds": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "tolerateMaster": {
+              "type": "boolean"
+            },
+            "tolerations": {
+              "type": "array"
+            },
+            "updateStrategy": {
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "tls": {
+          "properties": {
+            "cipherSuites": {
+              "type": "string"
+            },
+            "controllerMetricsTLSSecret": {
+              "type": "string"
+            },
+            "curvePreferences": {
+              "type": "string"
+            },
+            "minVersion": {
+              "type": "string"
+            },
+            "speakerMetricsTLSSecret": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/zarf-values.yaml
+++ b/zarf-values.yaml
@@ -1,0 +1,11 @@
+# Copyright 2026 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+# Zarf Values defaults for the metallb package. Each top-level key maps onto one chart
+# (see zarf.yaml and common/zarf.yaml). Defaults intentionally stay empty so chart and
+# flavor values files remain the single source of truth; deployers override only what
+# they need. The existing Zarf variables (IP_ADDRESS_POOL, INTERFACE, etc.) continue to
+# work unchanged alongside these values.
+exemption: {}
+metallb: {}
+addresspools: {}

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -35,6 +35,11 @@ variables:
     default: ""
     prompt: false
 
+values:
+  files:
+    - zarf-values.yaml
+  schema: zarf-values.schema.json
+
 components:
   - name: metallb-uds-exemption
     description: Ensure that the speaker pod is allowed to schedule
@@ -45,6 +50,9 @@ components:
         namespace: uds-policy-exemptions
         localPath: ./charts/exemption
         version: 0.1.0
+        values:
+          - sourcePath: .exemption
+            targetPath: .
 
   - name: metallb
     required: true


### PR DESCRIPTION
## Description

Adds a [Zarf Values](https://docs.defenseunicorns.com/core/concepts/configuration--packaging/package-values/) passthrough to this package, so deployers (bundles, and Fleet Command per-group values) can configure the charts directly without bundle overrides.

Part of the series following the shape validated on [uds-packages/cert-manager#247](https://github.com/uds-packages/cert-manager/pull/247) and [uds-packages/jaeger#72](https://github.com/uds-packages/jaeger/pull/72).

**MetalLB keeps both configuration channels intentionally** (decision by Eddie, 2026-07-20): all existing Zarf `variables` (`IP_ADDRESS_POOL`, `IP_ADDRESS_ADMIN_INGRESSGATEWAY`, `IP_ADDRESS_PASSTHROUGH_INGRESSGATEWAY`, `IP_ADDRESS_TENANT_INGRESSGATEWAY`, `INTERFACE`) are left completely untouched so existing variables-based deployments keep working unchanged, and the same configuration additionally becomes reachable through values. MetalLB is configurable via variables or values.

## Changes

- `common/zarf.yaml`: each chart maps a top-level values key onto its Helm values root, per the [uds-common nginx reference](https://github.com/defenseunicorns/uds-common/blob/main/zarf.yaml):
  - `metallb` → upstream MetalLB chart, with `excludePaths` guarding package integrity: `imagePullSecrets`, `controller.image`, `speaker.image`, the deprecated FRR sidecar image (`speaker.frr.image`), the `crds` toggles, both security contexts (`controller.securityContext`, `speaker.securityContext`), and the frr-k8s subchart's image and CRD keys (`frr-k8s.frrk8s.image`, `frr-k8s.frrk8s.frr.image`, `frr-k8s.crds`)
  - `addresspools` → local address pools chart, fully exposed (no `excludePaths`): IP address pools, L2 advertisement selectors, and `interface` stay configurable, alongside the existing chart `variables`
- `zarf.yaml`: `exemption` → local UDS exemption chart (`exemptionEnabled` toggle), plus the top-level `values` block referencing `zarf-values.yaml` + `zarf-values.schema.json`
- `zarf-values.yaml`: intentionally empty per-chart keys; chart defaults and flavor values files stay the single source of truth
- `zarf-values.schema.json`: generated with `zarf dev generate-schema . -f upstream -u` (zarf v0.81.0). Mappings live in `common/` so the schema is identical across flavors.

## Validation

- Leak-hunted the generated schema: no `image`, `tag`, `repository`, `imagePullSecrets`, `securityContext`, or `crds` keys present; address pool, L2 advertisement, and `interface` keys remain exposed
- `zarf dev lint . -f upstream|registry1|unicorn` passes with zero errors (only the pre-existing image-pinning warnings)
- uds-common pins are already at v1.26.3 (tasks and workflow refs), which supports the `values` key, so no CI bump is needed
- Full package create/deploy left to CI

## Notes for review

- `speaker.frr.enabled` and `frrk8s.enabled` remain exposed (consistent with the rest of the series which keeps component enable toggles open). Enabling them in an airgap would fail since the FRR images are not in the package. Happy to exclude if preferred.
